### PR TITLE
Ubuntu24.04 ê cuda編譯有問題，先mài build。

### DIFF
--- a/Dockerfile-ubuntu-cuda
+++ b/Dockerfile-ubuntu-cuda
@@ -1,5 +1,7 @@
 FROM nvidia/cuda:12.6.2-cudnn-devel-ubuntu24.04 AS base
 
+# https://github.com/i3thuan5/PianHo-e-Kaldi/issues/4 ài處理
+
 ENV LANG C.utf8
 
 RUN apt-get update && \

--- a/build.sh
+++ b/build.sh
@@ -13,11 +13,6 @@ docker build --pull \
 docker push ithuan/pianho-e-kaldi:ubuntu-24.04
 
 docker build --pull \
-	-f Dockerfile-ubuntu-cuda . \
-	-t ithuan/pianho-e-kaldi:ubuntu-cuda
-docker push ithuan/pianho-e-kaldi:ubuntu-cuda
-
-docker build --pull \
 	-f Dockerfile-ubuntu22.04-cuda . \
 	-t ithuan/pianho-e-kaldi:ubuntu22.04-cuda
 docker push ithuan/pianho-e-kaldi:ubuntu22.04-cuda


### PR DESCRIPTION
因為有 #4 問題而且：

- 主機上新nvidia驅動kan-na支援 cuda 12.4
- 無ubuntu24.04配cuda12.5.1前ê版本

所以先mài處理 ubuntu24.04 配 cuda ê image