### PR TITLE
Ka-tī更新OS套件，因為nvidia/cuda bē更新docker image

### DIFF
--- a/Dockerfile-ubuntu22.04-cuda
+++ b/Dockerfile-ubuntu22.04-cuda
@@ -3,6 +3,7 @@ FROM nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04 AS base
 ENV LANG C.utf8
 
 RUN apt-get update && \
+    apt-get upgrade -y --no-install-recommends && \
     apt-get install -y --no-install-recommends \
         language-pack-en \
         python3 \

--- a/build.sh
+++ b/build.sh
@@ -3,16 +3,19 @@
 set -euxo pipefail
 
 docker build --pull \
+	--no-cache-filter base \
 	-f Dockerfile-debian . \
 	-t ithuan/pianho-e-kaldi:debian-bookworm
 docker push ithuan/pianho-e-kaldi:debian-bookworm
 
 docker build --pull \
+	--no-cache-filter base \
 	-f Dockerfile-ubuntu . \
 	-t ithuan/pianho-e-kaldi:ubuntu-24.04
 docker push ithuan/pianho-e-kaldi:ubuntu-24.04
 
 docker build --pull \
+	--no-cache-filter base \
 	-f Dockerfile-ubuntu22.04-cuda . \
 	-t ithuan/pianho-e-kaldi:ubuntu22.04-cuda
 docker push ithuan/pianho-e-kaldi:ubuntu22.04-cuda


### PR DESCRIPTION
## 更新前
![本底](https://github.com/user-attachments/assets/fce94636-8e3a-4642-bd27-4c1149a880f3)
## 更新後
![更新後](https://github.com/user-attachments/assets/00a9cece-346c-4435-8428-cd08196f69df)
